### PR TITLE
Fixes issue- Fails with Ubuntu 18.04

### DIFF
--- a/RulerActivity.py
+++ b/RulerActivity.py
@@ -65,11 +65,11 @@ class MyCanvas(Gtk.DrawingArea):
         
         self._draw_ruler = False
         self._object = None
-        self.connect('draw', self.__expose_event_cb)
+        self.connect('draw', self.__draw_cb)
         self._dpi = 96
 
-    def __expose_event_cb(self, drawing_area, event):
-        cr = self.get_property('window').cairo_create()
+    def __draw_cb(self,widget, cr):
+
 
         if self._draw_ruler:
             self._object.draw(cr, self._dpi)
@@ -274,7 +274,7 @@ class RulerActivity(activity.Activity):
         self._canvas.add_a_ruler(self._r)
         self._r.custom_unit_in_mm = new
         self._r.draw_custom_ruler(self._r.custom_unit_in_mm)
-        self.metadata['custom_unit'] = new
+        self.metadata['custom_unit'] = str(new)
 
     def _grids_cb(self, button=None):
         if self._ready:

--- a/RulerActivity.py
+++ b/RulerActivity.py
@@ -244,7 +244,7 @@ class RulerActivity(activity.Activity):
             self.rulers.set_active(True)
 
         if 'custom_unit' in self.metadata:
-            self.custom_unit_entry.set_text(str(self.metadata['custom_unit']))
+            self.custom_unit_entry.set_text(self.metadata['custom_unit'])
         else: # set the default
             self.custom_unit_entry.set_text("25.4")
 

--- a/RulerActivity.py
+++ b/RulerActivity.py
@@ -21,7 +21,7 @@
 import gi
 from gi.repository import Gtk
 from gi.repository import GObject
-from gi.repository import GdkX11
+from gi.repository import Gdk
 
 import cairo
 
@@ -110,7 +110,7 @@ class RulerActivity(activity.Activity):
         self.set_canvas(self._canvas)
         self._canvas.show()
 
-        screen = GdkX11.X11Screen()
+        screen = Gdk.Screen()
         width = screen.width()
         height = screen.height() - GRID_CELL_SIZE
 

--- a/RulerActivity.py
+++ b/RulerActivity.py
@@ -68,8 +68,7 @@ class MyCanvas(Gtk.DrawingArea):
         self.connect('draw', self.__draw_cb)
         self._dpi = 96
 
-    def __draw_cb(self,widget, cr):
-
+    def __draw_cb(self, widget, cr):
 
         if self._draw_ruler:
             self._object.draw(cr, self._dpi)

--- a/show_rulers.py
+++ b/show_rulers.py
@@ -65,10 +65,11 @@ class ScreenOfRulers():
             self.draw_custom_ruler(self.custom_unit_in_mm, int(nw / 10 * 10))
 
         else:
-            self.offset_of_xo_side_from_screen = mm(dpi, 0)
+            l = int( nw / 20 )
+            self.offset_of_xo_side_from_screen = mm(dpi, l)
             c.move_to(self.offset_of_xo_side_from_screen,  mm(dpi, 65))
-            self.draw_cm_ruler(c, dpi, int(nw / 10 * 10))
-            self.draw_custom_ruler(self.custom_unit_in_mm, int(nw / 10 * 10))
+            self.draw_cm_ruler(c, dpi, int((nw / 10 * 10) - l))
+            self.draw_custom_ruler(self.custom_unit_in_mm, int((nw / 10 * 10) - l))
             
     def draw_ruler_pair(self, c, dpi, y):
         c.move_to(mm(dpi, 10), y)

--- a/show_rulers.py
+++ b/show_rulers.py
@@ -65,11 +65,10 @@ class ScreenOfRulers():
             self.draw_custom_ruler(self.custom_unit_in_mm, int(nw / 10 * 10))
 
         else:
-            l = int( nw / 20 )
-            self.offset_of_xo_side_from_screen = mm(dpi, l)
+            self.offset_of_xo_side_from_screen = mm(dpi, int(nw / 20))
             c.move_to(self.offset_of_xo_side_from_screen,  mm(dpi, 65))
-            self.draw_cm_ruler(c, dpi, int((nw / 10 * 10) - l))
-            self.draw_custom_ruler(self.custom_unit_in_mm, int((nw / 10 * 10) - l))
+            self.draw_cm_ruler(c, dpi, int(nw / 11 * 10))
+            self.draw_custom_ruler(self.custom_unit_in_mm, int(nw / 11 * 10))
             
     def draw_ruler_pair(self, c, dpi, y):
         c.move_to(mm(dpi, 10), y)

--- a/util.py
+++ b/util.py
@@ -100,11 +100,10 @@ def set_color(c, name):
 
 
 def write(c, text, name, size, centered=False, at_top=False):
-    pc = PangoCairo.create_context(c)
 
     font = Pango.FontDescription(name)
     font.set_size(int(round(size * Pango.SCALE)))
-    lo = PangoCairo.create_layout(pc)
+    lo = PangoCairo.create_layout(c)
     lo.set_font_description(font)
     lo.set_text('X', -1)
     baseline_offset = lo.get_baseline() / Pango.SCALE


### PR DESCRIPTION
Pr should fix #6 . I have tested with Ubuntu 18.04. 
In utils.py,[(line 107](https://github.com/sugarlabs/ruler/blob/master/util.py#L107)) PangoCairo.create_layout method takes cairo.Context as argument. As cairo.Context argument is already given by  RulerActivity.py in [line 75](https://github.com/sugarlabs/ruler/blob/master/RulerActivity.py#L75). So there is no need to create context again in util.py([line 103](https://github.com/sugarlabs/ruler/blob/master/util.py#L103)).
@quozl Please review.

Fixes #10.